### PR TITLE
Add 2FA (TOTP) Setup to Profile Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@capacitor/status-bar": "7.0.0",
         "@ionic/react": "^8.0.0",
         "@ionic/react-router": "^8.0.0",
-        "@supabase/supabase-js": "^2.49.4",
+        "@supabase/supabase-js": "^2.49.8",
         "@types/react-router": "^5.1.20",
         "@types/react-router-dom": "^5.3.3",
         "bcryptjs": "^3.0.2",
@@ -3178,9 +3178,9 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.4.tgz",
-      "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
+      "version": "2.49.8",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
+      "integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/auth-js": "2.69.1",
@@ -4379,6 +4379,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
       "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
-  "homepage": "https://tiptip123.github.io/it35-lab",
+  "homepage": "https://bujirenso.github.io/it35-lab-tiptip123",
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/status-bar": "7.0.0",
     "@ionic/react": "^8.0.0",
     "@ionic/react-router": "^8.0.0",
-    "@supabase/supabase-js": "^2.49.4",
+    "@supabase/supabase-js": "^2.49.8",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "bcryptjs": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
-  "homepage": "https://bujirenso.github.io/it35-lab-tiptip123",
+  "homepage": "https://tiptip123.github.io/it35-lab",
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ import {
   useIonRouter
 } from '@ionic/react';
 import { personCircleOutline } from 'ionicons/icons'; // Changed to a more professional user icon
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
 
 const AlertBox: React.FC<{ message: string; isOpen: boolean; onClose: () => void }> = ({ message, isOpen, onClose }) => {
@@ -35,9 +35,29 @@ const Login: React.FC = () => {
   const [showToast, setShowToast] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
+  // 2FA states
+  const [show2FAModal, setShow2FAModal] = useState(false);
+  const [twoFACode, setTwoFACode] = useState('');
+  const [challengeId, setChallengeId] = useState('');
+  const [factorId, setFactorId] = useState('');
+
+  // Helper to fetch the user's TOTP factorId
+  const fetchTOTPFactorId = async () => {
+    const { data: factors } = await supabase.auth.mfa.listFactors();
+    if (factors && factors.totp.length > 0) {
+      return factors.totp[0].id;
+    }
+    return '';
+  };
+
   const doLogin = async () => {
     setIsLoading(true);
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setShow2FAModal(false);
+    setTwoFACode('');
+    setChallengeId('');
+    setFactorId('');
+    // Step 1: Try normal login
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
     if (error) {
       setAlertMessage(error.message);
@@ -46,13 +66,48 @@ const Login: React.FC = () => {
       return;
     }
 
+    // Step 2: Check if MFA challenge is required
+    if (data && 'mfa' in data && (data as any).mfa) {
+      const mfaData = (data as any).mfa;
+      setChallengeId(mfaData.id);
+      // Get the user's TOTP factorId
+      const fetchedFactorId = await fetchTOTPFactorId();
+      setFactorId(fetchedFactorId);
+      setShow2FAModal(true);
+      setIsLoading(false);
+      return;
+    }
+
+    // Step 3: Success, no 2FA required
     setShowToast(true);
     setIsLoading(false);
     setTimeout(() => {
       navigation.push('/it35-lab/app', 'forward', 'replace');
     }, 300);
   };
-  
+
+  // 2FA verification handler
+  const handle2FAVerify = async () => {
+    setIsLoading(true);
+    const { error } = await supabase.auth.mfa.verify({
+      factorId,
+      challengeId,
+      code: twoFACode
+    });
+    if (error) {
+      setAlertMessage(error.message);
+      setShowAlert(true);
+      setIsLoading(false);
+      return;
+    }
+    setShow2FAModal(false);
+    setShowToast(true);
+    setIsLoading(false);
+    setTimeout(() => {
+      navigation.push('/it35-lab/app', 'forward', 'replace');
+    }, 300);
+  };
+
   return (
     <IonPage>
       <IonContent className="ion-padding" color="light">
@@ -120,6 +175,37 @@ const Login: React.FC = () => {
             </div>
           </div>
         </div>
+
+        {/* 2FA Modal */}
+        <IonAlert
+          isOpen={show2FAModal}
+          onDidDismiss={() => setShow2FAModal(false)}
+          header="Two-Factor Authentication Required"
+          message={
+            `<div>Please enter the 6-digit code from your authenticator app.</div>` +
+            `<input id='totp-input' type='number' placeholder='Enter 2FA code' style='width: 100%; margin-top: 10px; padding: 8px;' />`
+          }
+          buttons={[
+            {
+              text: 'Verify',
+              handler: async () => {
+                // Get the value from the input
+                const input = document.getElementById('totp-input') as HTMLInputElement;
+                setTwoFACode(input.value);
+                // Wait for state to update, then call verify
+                setTimeout(handle2FAVerify, 100);
+                return false;
+              }
+            },
+            {
+              text: 'Cancel',
+              role: 'cancel',
+              handler: () => setShow2FAModal(false)
+            }
+          ]}
+          // Prevent closing by clicking outside
+          backdropDismiss={false}
+        />
 
         {/* Reusable AlertBox Component */}
         <AlertBox message={alertMessage} isOpen={showAlert} onClose={() => setShowAlert(false)} />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -59,6 +59,8 @@ const Login: React.FC = () => {
     // Step 1: Try normal login
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
+    console.log('Login response:', data);
+
     if (error) {
       setAlertMessage(error.message);
       setShowAlert(true);


### PR DESCRIPTION
This PR adds the ability for users to enable and disable Two-Factor Authentication (2FA) using TOTP (authenticator app) from their profile page.

in the edit profile page scroll down 

![image](https://github.com/user-attachments/assets/3a66add4-d2aa-41c6-9254-45aee5cf91e8)


-Users can enable 2FA by scanning a QR code and verifying with a 6-digit code from their authenticator app.
-Users can disable 2FA after confirming with a 2FA code.
-2FA status is displayed in the profile page.


What’s Not Included / Known Issues:
2FA prompt is NOT shown on login yet.
The login page does not currently prompt for a 2FA code after entering correct credentials, even if 2FA is enabled for the user.
The 2FA setup and removal UI is only available in the profile page.
2FA backend logic is in place, but frontend login flow for 2FA is not yet functional.


How to Test:
Go to the edit profile page.
Download Google Authenticator app to scan the QR code that is being popped up when enabling 2FA
Enable 2FA and verify with an authenticator app.
Disable 2FA by entering the 2FA code.
Try logging in (note: 2FA prompt will NOT appear yet).


